### PR TITLE
Remove calls to version_find_latest

### DIFF
--- a/08_zbectl
+++ b/08_zbectl
@@ -189,9 +189,15 @@ title_correction_code=
 # yet, so it's empty. In a submenu it will be equal to '\t' (one tab).
 submenu_indentation=""
 
+# Perform a reverse version sort on the entire list.
+# Temporarily replace the '.old' suffix by ' 1' and append ' 2' for all
+# other files to order the '.old' files after their non-old counterpart
+# in reverse-sorted order.
+
+reverse_sorted_list=$(echo $list | tr ' ' '\n' | sed -e 's/\.old$/ 1/; / 1$/! s/$/ 2/' | version_sort -r | sed -e 's/ 1$/.old/; s/ 2$//')
+
 is_top_level=true
-while [ "x$list" != "x" ] ; do
-  linux=`version_find_latest $list`
+for linux in ${reverse_sorted_list}; do
   gettext_printf "Found linux image: %s\n" "$linux" >&2
   basename=`basename $linux`
   dirname=`dirname $linux`
@@ -283,8 +289,6 @@ while [ "x$list" != "x" ] ; do
     linux_entry "${OS}${environment}" "${version}" recovery \
                 "single ${GRUB_CMDLINE_LINUX}"
   fi
-
-  list=`echo $list | tr ' ' '\n' | fgrep -vx "$linux" | tr '\n' ' '`
 done
 
 # If at least one kernel was found, then we need to

--- a/zbectl
+++ b/zbectl
@@ -176,7 +176,7 @@ partition_device() {
 			--largest-new=2 --typecode:2:bf00 \
 			$device 1>/dev/null
 
-		[[ $? ]] || die 3 "error paritioning device: '$device'"
+		[[ $? ]] || die 3 "error partitioning device: '$device'"
 
 		mkfs.fat -F32 $(fdisk -l $device | awk '/EFI System/{print $1}') 1>/dev/null
 		[[ $? ]] || die 3 "error creating EFI filesystem: '$device'"
@@ -186,7 +186,7 @@ partition_device() {
 			--largest-new=2 --typecode:2:bf00 \
 			$device 1>/dev/null
 
-		[[ $? ]] || die 3 "error paritioning device: '$device'"
+		[[ $? ]] || die 3 "error partitioning device: '$device'"
 	fi
 }
 update_grub() {
@@ -316,7 +316,7 @@ case $subcmd in
 	ENTRIES="$(grep ^menuentry $GRUBCFG | cut -d "'" -f2)"
 	if [[ $# -eq 0 ]]
 	then
-		echo "Avialiable environments:"
+		echo "Available environments:"
 		echo "$ENTRIES"
 		exit 0
 	fi


### PR DESCRIPTION
Upstream grub has removed the `version_find_latest` function used in the `08_zbectl` script in commit a79c567f6. This PR updates `08_zbectl` similarly to how the `10_linux` script was updated in upstream grub commit 99e05ab55. It also fixes a few more spelling mistakes found in some output strings